### PR TITLE
Caretaker menu kj

### DIFF
--- a/components/AddTask.js
+++ b/components/AddTask.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { View, StyleSheet, TextInput } from "react-native";
 import { Button } from "react-native-elements";
 
-class AddTimer extends React.Component {
+class AddTask extends React.Component {
   constructor() {
     super();
     this.state = {
@@ -81,4 +81,4 @@ const styles = StyleSheet.create({
   }
 })
 
-export default AddTimer;
+export default AddTask;

--- a/components/Caretaker.js
+++ b/components/Caretaker.js
@@ -1,6 +1,6 @@
 import React, {useState} from "react";
 import { Button, Header, BottomSheet } from 'react-native-elements';
-import { View, Text, TouchableOpacity, StyleSheet, FlatList } from "react-native";
+import { View, Text, TouchableOpacity, StyleSheet, FlatList, Modal } from "react-native";
 import Times from './Times';
 import AddTimer from './AddTimer';
 import { CardStyleInterpolators } from "react-navigation-stack";
@@ -30,7 +30,7 @@ const Caretaker = ({history, navigation}) => {
     })
   }
 
-  const [isVisible, setIsVisible] = useState(false);
+  const [modalVisible, setIsVisible] = useState(false);
 
   return (
     <View>
@@ -50,10 +50,10 @@ const Caretaker = ({history, navigation}) => {
           keyExtractor={(item) => item.id.toString()}
         />  
 
-      <BottomSheet isVisible={isVisible} containerStyle={{}}>
-        <Button buttonStyle={styles.buttonStyle} title='x' titleStyle={styles.titleStyle} onPress={() => setIsVisible(false)}></Button>
+      <Modal visible={modalVisible} containerStyle={styles.addTaskMenu}>
+        <Button buttonStyle={styles.buttonStyle} title='x' titleStyle={styles.titleStyle} onPress={() => setIsVisible(!modalVisible)}></Button>
         <AddTimer addTimer={addTimer} setIsVisible={setIsVisible}/>
-      </BottomSheet>
+      </Modal>
 
     </View>
   );
@@ -82,6 +82,10 @@ const styles = StyleSheet.create({
   },
   titleStyle: {
     fontSize: 30
+  },
+  addTaskMenu: {
+    display: "flex",
+    justifyContent: "flex-start"
   }
 })
 

--- a/components/Caretaker.js
+++ b/components/Caretaker.js
@@ -50,8 +50,8 @@ const Caretaker = ({history, navigation}) => {
           keyExtractor={(item) => item.id.toString()}
         />  
 
-      <Modal visible={modalVisible} >
-        <Button buttonStyle={styles.buttonStyle} title='x' titleStyle={styles.titleStyle} onPress={() => setIsVisible(!modalVisible)}></Button>
+      <Modal visible={modalVisible} animationType="slide">
+        <Button buttonStyle={styles.buttonStyle} title='Close Menu' titleStyle={styles.titleStyle} onPress={() => setIsVisible(!modalVisible)}></Button>
         <AddTask addTimer={addTimer} setIsVisible={setIsVisible}/>
       </Modal>
 
@@ -77,11 +77,13 @@ const styles = StyleSheet.create({
     width: "auto", 
     alignSelf: "flex-end",
     textAlign: "center",
-    margin: 20,
+    marginTop: 50,
+    marginRight: 30,
     padding: 10,
   },
   titleStyle: {
-    fontSize: 30
+    fontSize: 20,
+    fontWeight: "bold"
   }
 })
 

--- a/components/Caretaker.js
+++ b/components/Caretaker.js
@@ -2,7 +2,7 @@ import React, {useState} from "react";
 import { Button, Header, BottomSheet } from 'react-native-elements';
 import { View, Text, TouchableOpacity, StyleSheet, FlatList, Modal } from "react-native";
 import Times from './Times';
-import AddTimer from './AddTimer';
+import AddTask from './AddTask';
 import { CardStyleInterpolators } from "react-navigation-stack";
 
 const Caretaker = ({history, navigation}) => {
@@ -50,9 +50,9 @@ const Caretaker = ({history, navigation}) => {
           keyExtractor={(item) => item.id.toString()}
         />  
 
-      <Modal visible={modalVisible} containerStyle={styles.addTaskMenu}>
+      <Modal visible={modalVisible} >
         <Button buttonStyle={styles.buttonStyle} title='x' titleStyle={styles.titleStyle} onPress={() => setIsVisible(!modalVisible)}></Button>
-        <AddTimer addTimer={addTimer} setIsVisible={setIsVisible}/>
+        <AddTask addTimer={addTimer} setIsVisible={setIsVisible}/>
       </Modal>
 
     </View>
@@ -82,10 +82,6 @@ const styles = StyleSheet.create({
   },
   titleStyle: {
     fontSize: 30
-  },
-  addTaskMenu: {
-    display: "flex",
-    justifyContent: "flex-start"
   }
 })
 

--- a/components/Caretaker.js
+++ b/components/Caretaker.js
@@ -1,9 +1,8 @@
 import React, {useState} from "react";
-import { Button, Header, BottomSheet } from 'react-native-elements';
-import { View, Text, TouchableOpacity, StyleSheet, FlatList, Modal } from "react-native";
+import { Button, Header } from 'react-native-elements';
+import { View, StyleSheet, FlatList, Modal } from "react-native";
 import Times from './Times';
 import AddTask from './AddTask';
-import { CardStyleInterpolators } from "react-navigation-stack";
 
 const Caretaker = ({history, navigation}) => {
   const [timers, editTimers] = useState([

--- a/components/Receiver.js
+++ b/components/Receiver.js
@@ -9,12 +9,13 @@ class Receiver extends Component {
     super();
     this.state = {
       timers: [
-        {id: 1, category: "Wake-up", time: '7:00', window: '0:15'},
+        {id: 1, category: "Wake-up", time: '7:00', window: '0:15', completed: "false"},
         {id: 2, category: "Take meds", time: '12:00', window: '1:00'},
         {id: 3, category: "go to sleep", time: '22:00', window: '1:00'}
       ]
     }
   }
+  
   render () {
     return (
       <SafeAreaView>
@@ -26,7 +27,7 @@ class Receiver extends Component {
           />
         <ScrollView snapToAlignment="center" decelerationRate="fast" horizontal >
           {this.state.timers.map((task) => {
-            return <View style={styles.task}>
+            return <View style={styles.task} key={task.id}>
               <Checkin />
               <View>
                 <Text style={styles.taskCategory}>{task.category}</Text>


### PR DESCRIPTION
### Participating Group Members:
 @kathrynljackson 

### Code Highlights:
* Add a unique key to the components created using `.map()`
* `BottomSheet` is now `Modal` so that the menu renders at the top of the screen instead of at the bottom, causing it to be blocked by the keyboard. The app still doesn't render dynamically, so this still may be a problem on different devices, especially smaller ones. 
* The `AddTimer` components is now `AddTask` in order to be more accurate and easier to find. 
* I did enough styling on the `Modal` to make it usable, but it could definitely use some more help. Adding the `animationType` prop makes it slide in and out like the `BottomSheet` did. I didn't look into other animations but that might be fun for an extension. 
 
### Have Tests Been Added?
- [x] No.
- [ ] Yes, but all tests are not passing. 
- [ ] Yes, and all are passing.
 
### Any background context you want to provide?
* n/a 
 
### Any packages installed?
* No
 
### Message/Questions for reviewer:
* What styling changes should still be made? Please post them as a comment so that I can make them into an issue. 
 
### Issues: 
* Closes #20 
* Closes #28
 
### Screenshots (if appropriate): 
 
https://user-images.githubusercontent.com/65988644/104050165-3203b900-51b4-11eb-976d-209ad55664e5.mov


### Tracking Consistency:
- [x] added appropriate labels
- [x] My code follows the code style of this project and has removed all unnecessary annotations
- [x] I have added comments on my pull request, particularly in hard-to-understand areas
~~- [ ] All new and existing tests passed  ~~
- [x] looked at PR preview to check spelling, syntax, formatting, and completion
 
## Tags (for mentor/alumni code review)
@nicorithner @sarynm12 @D-Lessenden 